### PR TITLE
close opened file descriptors properly

### DIFF
--- a/system/tools/mkbootfs.c
+++ b/system/tools/mkbootfs.c
@@ -163,6 +163,7 @@ int import_manifest(const char *fn, unsigned *hdrsz, fs *fs) {
         char* dstfn = trim(line);
         char* srcfn = trim(eq);
         if ((e = import_manifest_entry(fn, lineno, dstfn, srcfn)) == NULL) {
+            fclose(fp);
             return -1;
         }
         sz += add_entry(fs, e);

--- a/system/uapp/mxsh/mxsh.c
+++ b/system/uapp/mxsh/mxsh.c
@@ -537,6 +537,7 @@ void execscript(const char* fn) {
     while (fgets(line, sizeof(line), fp) != NULL) {
         execline(line);
     }
+    fclose(fp);
 }
 
 void console(void) {


### PR DESCRIPTION
Calling `fclose()` will ensure the file descriptor is properly disposed of and output buffers flushed so the data written to the file will be present in the file on disk.

Found by https://github.com/bryongloden/cppcheck