### PR TITLE
pmm: Don't give up when the first physical memory region is exhausted.

### DIFF
--- a/kernel/kernel/vm/pmm.cpp
+++ b/kernel/kernel/vm/pmm.cpp
@@ -162,6 +162,10 @@ size_t pmm_alloc_pages(size_t count, uint alloc_flags, struct list_node* list) {
                 continue;
         }
         while (allocated < count) {
+            /* Go to the next arena if this one's free list is exhausted. */
+            if (!a->free_count)
+                continue;
+
             vm_page_t* page = list_remove_head_type(&a->free_list, vm_page_t, node);
             if (!page)
                 return allocated;


### PR DESCRIPTION
As far as I can see nothing removes an empty physical memory arenas from the
list. If such an arena is run across when in pmm_alloc_pages, the function
will stop looking for pages and return the number it's found thus far. That
may not be the number requested, and may even be zero if there was a totally
exhausted arena (unless I'm missing something).

This change prevents a "blue screen" when booting with depthcharge and OVMF on
QEMU.

Change-Id: I01d75597aa114816122f500098ce35d5621dbddd